### PR TITLE
Stratified bed files

### DIFF
--- a/validation/parse_validation_results.py
+++ b/validation/parse_validation_results.py
@@ -134,6 +134,7 @@ def main(
 
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
     parser = ArgumentParser()
     parser.add_argument('--id', help='CPG ID for this sample')
     parser.add_argument('--folder', help='Location for results')

--- a/validation/parse_validation_results.py
+++ b/validation/parse_validation_results.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 """
-run locally to upload the validation results to metamist
+Runs after the validation process to digest results
+A summary of those results are posted into Metamist
 """
+
+
 import logging
 from argparse import ArgumentParser
 from csv import DictReader
@@ -110,8 +113,12 @@ def main(
             for sub_key, sub_value in SUMMARY_KEYS.items():
                 summary_data[f'{summary_key}::{sub_value}'] = str(line[sub_key])
 
+    # store the full paths of all files created during the analysis
     for file in sample_results:
         summary_data[file.name.replace(f'{cpg_id}.', '')] = str(file.absolute())
+
+    # print the contents, even if the metamist write fails (e.g. on test)
+    logging.info(summary_data)
 
     AnalysisApi().create_new_analysis(
         project=get_config()['workflow']['dataset'],

--- a/validation/parse_validation_results.py
+++ b/validation/parse_validation_results.py
@@ -7,8 +7,7 @@ import logging
 from argparse import ArgumentParser
 from csv import DictReader
 
-from cloudpathlib import CloudPath
-
+from cpg_utils import to_path
 from cpg_utils.config import get_config
 
 from sample_metadata.apis import AnalysisApi
@@ -21,13 +20,8 @@ from sample_metadata.model.analysis_query_model import AnalysisQueryModel
 ANAL_API = AnalysisApi()
 SUMMARY_KEYS = {
     'TRUTH.TOTAL': 'true_variants',
-    'QUERY.TOTAL': 'pipeline_variants',
-    'TRUTH.TP': 'matched_variants',
-    'TRUTH.FN': 'false_negatives',
-    'QUERY.FP': 'false_positives',
     'METRIC.Recall': 'recall',
     'METRIC.Precision': 'precision',
-    'METRIC.F1_Score': 'f1_score',
 }
 
 
@@ -62,6 +56,7 @@ def main(
     truth_vcf: str,
     truth_bed: str,
     joint_mt: str,
+    stratified: str | None = None,
 ):
     """
     parses for this sample's analysis results
@@ -76,6 +71,7 @@ def main(
     truth_vcf : the sample truth VCF
     truth_bed : the confident regions BED
     joint_mt : the original joint-call MatrixTable
+    stratified : if analysis was stratified, this is the location of files
     """
 
     # if a result already exists, quietly exit so as not to cancel other sample's jobs
@@ -86,10 +82,11 @@ def main(
         )
         return
 
-    sample_results = list(CloudPath(comparison_folder).glob(f'{cpg_id}*'))
+    # list from the generator, so we can re-iterate
+    sample_results = list(to_path(comparison_folder).glob(f'{cpg_id}*'))
 
     # pick out the summary file
-    summary_file = [file for file in sample_results if 'summary.csv' in file.name][0]
+    summary_file = [file for file in sample_results if 'extended.csv' in file.name][0]
 
     # populate a dictionary of results for this sample
     summary_data = {
@@ -99,17 +96,23 @@ def main(
         'truth_vcf': truth_vcf,
         'truth_bed': truth_bed,
     }
+
+    if stratified:
+        summary_data['stratified'] = stratified
+
     with summary_file.open() as handle:
         summary_reader = DictReader(handle)
         for line in summary_reader:
-            summary_key = f'{line["Type"]}_{line["Filter"]}'
+            if line['Filter'] != 'PASS' or line['Subtype'] != '*':
+                continue
+
+            summary_key = f'{line["Type"]}_{line["Subset"]}'
             for sub_key, sub_value in SUMMARY_KEYS.items():
                 summary_data[f'{summary_key}::{sub_value}'] = str(line[sub_key])
 
     for file in sample_results:
         summary_data[file.name.replace(f'{cpg_id}.', '')] = str(file.absolute())
 
-    # should the output be the summary file rather than the VCF? Hmm
     AnalysisApi().create_new_analysis(
         project=get_config()['workflow']['dataset'],
         analysis_model=AnalysisModel(
@@ -131,6 +134,9 @@ if __name__ == '__main__':
     parser.add_argument('-t', help='truth VCF used')
     parser.add_argument('-b', help='BED used')
     parser.add_argument('--mt', help='Multisample MT')
+    parser.add_argument(
+        '--stratified', help='Stratification files, if used', required=False
+    )
     args = parser.parse_args()
     main(
         cpg_id=args.id,
@@ -139,4 +145,5 @@ if __name__ == '__main__':
         truth_vcf=args.t,
         truth_bed=args.b,
         joint_mt=args.mt,
+        stratified=args.stratified,
     )

--- a/validation/run_file.sh
+++ b/validation/run_file.sh
@@ -11,4 +11,4 @@ analysis-runner \
   --access-level test \
   validation/validation_runner.py \
     -i gs://cpg-validation-test/validation/copy/copy_of_exome_628.mt \
-    -s gs://cpg-validation-test/GRCh38_regions/twist/definition.tsv
+    -s gs://cpg-validation-test/GRCh38_regions/twist

--- a/validation/run_file.sh
+++ b/validation/run_file.sh
@@ -6,8 +6,9 @@ DATE=${1:-$(date +%F)}
 
 analysis-runner \
   --dataset validation \
-  --description "Run Exome Validation" \
+  --description "Run Exome Validation!" \
   -o $DATE \
-  --access-level standard \
+  --access-level test \
   validation/validation_runner.py \
-    -i gs://cpg-validation-main/exome/mt/dd7b2003026c7a6c70057a9c0f170074be6322_628-validation.mt
+    -i gs://cpg-validation-test/validation/copy/copy_of_exome_628.mt \
+    -s gs://cpg-validation-test/GRCh38_regions/twist/definition.tsv

--- a/validation/stratification.md
+++ b/validation/stratification.md
@@ -14,24 +14,12 @@ extended regions can be integrated into a validation run
 The genome-stratifications repository provides BED regions divided by genome build, then by category.
 Within these categories there is a lot of granularity. Here we are only using a subset of these in our validations.
 
-## Sub-Folders
-
-This folder contains two sub-folders; `genome` and `twist`. The `genome` folder contains the BED region
-files contained in the NCBI FTP site, spanning the whole genome. The `twist` folder contains analogous
-versions of each `genome` BED file, intersected with the [Twist Exome ROI](https://www.twistbioscience.com/resources/data-files/ngs-human-core-exome-panel-bed-file),
-which is the relevant region for exome analyses.
-
 ## Files
-
-Within `genome` and `twist` there are 2 types of files:
 
 1. `definition.tsv`, containing a short description and relative path to a BED file
 2. `*.bed.gz`, compressed files containing the region definitions for each category
 
-The `TSV` file is used by `hap.py` to locate region files, and annotate them in the output file with
-the short description.
-
-The files currently in use are:
+The `TSV` file is used by `hap.py` to locate region files, and annotate them in the output file with the short description. The files currently in use are:
 
 - `refseq_cds`: RefSeq Coding regions only [see here](https://github.com/genome-in-a-bottle/genome-stratifications/blob/master/GRCh38/FunctionalRegions/GRCh38-FunctionalRegions-README.md#data--file-overview)
 - `nonunique`: Mappability, regions of high homology over 250bp [see here](https://github.com/genome-in-a-bottle/genome-stratifications/blob/master/GRCh38/mappability/GRCh38-mappability-README.md#data--file-overview)
@@ -44,12 +32,19 @@ The files currently in use are:
 
 In practice, these files are used in the following way:
 
-- when running the validation workflow, provide the path to the BED directory of choice (e.g. `gs://cpg-validation-test/GRCh38_regions/twist`)
+- when running the validation workflow provide the path to the stratification directory of choice (e.g. `gs://cpg-validation-test/GRCh38_regions`)
 - when validation stages are being created, the script checks for a `definition.tsv` file, and copies all files into the execution container
-  - N.B. it is important that all the files are copied simultanously, otherwise Hail will copy all files into different temp folders
+  - N.B. it is important that all the files are copied simultaneously, otherwise Hail will copy all files into different temp folders
 - within the container, the hap.py script has the argument `--stratification /location/of/definition.tsv` added
 
 ## Results
 
 In the Hap.py output files there will be one ending with `extended.csv`, with entries for the whole (confident) ROI,
 then each separate stratified location. These results will be logged into metamist for the sample(s).
+
+I can't see where this is explicitly stated in the Hap.py documentation, but testing shows that the stratification
+regions are subsets within the confident regions. i.e. we don't require separate stratification folders for each capture,
+it is sufficient to update the confident regions BED, and all stratifications will be relative to that. In the hap.py
+codebase there are multiple layers in multiple languages, and as far as I can see the specific documentation that all
+stratified regions are subsets within the confident region is
+[this](https://github.com/Illumina/hap.py/blob/master/src/c%2B%2B/include/QuantifyRegions.hh#L98)

--- a/validation/stratification.md
+++ b/validation/stratification.md
@@ -1,0 +1,55 @@
+# Genomic Region Stratification
+
+[This folder](gs://cpg-validation-test/GRCh38_regions) contains the BED files used to further stratify the variant calling validation process.
+
+## Data Source
+
+These BED files are derived from the GIAB regions, which are defined/created in
+[this repository](https://github.com/genome-in-a-bottle/genome-stratifications/), and downloadable
+in full from [the corresponding FTP site](ftp://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/).
+The [Hap.py repository](https://github.com/Illumina/hap.py) contains a description of how these
+extended regions can be integrated into a validation run
+[here](https://github.com/Illumina/hap.py/blob/master/doc/happy.md#stratification-via-bed-regions).
+
+The genome-stratifications repository provides BED regions divided by genome build, then by category.
+Within these categories there is a lot of granularity. Here we are only using a subset of these in our validations.
+
+## Sub-Folders
+
+This folder contains two sub-folders; `genome` and `twist`. The `genome` folder contains the BED region
+files contained in the NCBI FTP site, spanning the whole genome. The `twist` folder contains analogous
+versions of each `genome` BED file, intersected with the [Twist Exome ROI](https://www.twistbioscience.com/resources/data-files/ngs-human-core-exome-panel-bed-file),
+which is the relevant region for exome analyses.
+
+## Files
+
+Within `genome` and `twist` there are 2 types of files:
+
+1. `definition.tsv`, containing a short description and relative path to a BED file
+2. `*.bed.gz`, compressed files containing the region definitions for each category
+
+The `TSV` file is used by `hap.py` to locate region files, and annotate them in the output file with
+the short description.
+
+The files currently in use are:
+
+- `refseq_cds`: RefSeq Coding regions only [see here](https://github.com/genome-in-a-bottle/genome-stratifications/blob/master/GRCh38/FunctionalRegions/GRCh38-FunctionalRegions-README.md#data--file-overview)
+- `nonunique`: Mappability, regions of high homology over 250bp [see here](https://github.com/genome-in-a-bottle/genome-stratifications/blob/master/GRCh38/mappability/GRCh38-mappability-README.md#data--file-overview)
+- `gnomAD inbreeding`: [gnomAD inbreedingcoeff variants](https://github.com/genome-in-a-bottle/genome-stratifications/blob/master/GRCh38/OtherDifficult/GRCh38-OtherDifficult-README.md#data--file-overview)
+- `MHC`: [chr6 MHC complex regions](https://github.com/genome-in-a-bottle/genome-stratifications/blob/master/GRCh38/OtherDifficult/GRCh38-OtherDifficult-README.md#data--file-overview)
+- `all_difficult`: Union of all complex regions (e.g. tandem repeats, all homopolymers >6bp, all imperfect homopolymers >10bp, all difficult to map regions, all segmental duplications, GC <25% or >65%, "Bad Promoters", chrX/Y XTR and ampliconic, satellites) [see](https://github.com/genome-in-a-bottle/genome-stratifications/blob/master/GRCh38/union/GRCh38-union-README.md#file-descriptions)
+- `not_in_all_difficult`: Complement, whole genome other than `all_difficult` regions
+
+## Usage
+
+In practice, these files are used in the following way:
+
+- when running the validation workflow, provide the path to the BED directory of choice (e.g. `gs://cpg-validation-test/GRCh38_regions/twist`)
+- when validation stages are being created, the script checks for a `definition.tsv` file, and copies all files into the execution container
+  - N.B. it is important that all the files are copied simultanously, otherwise Hail will copy all files into different temp folders
+- within the container, the hap.py script has the argument `--stratification /location/of/definition.tsv` added
+
+## Results
+
+In the Hap.py output files there will be one ending with `extended.csv`, with entries for the whole (confident) ROI,
+then each separate stratified location. These results will be logged into metamist for the sample(s).

--- a/validation/validation_runner.py
+++ b/validation/validation_runner.py
@@ -219,7 +219,7 @@ def comparison_job(
         ), 'There were no bed files in the stratified BED folder'
 
         # create a dictionary to pass to a the input generation
-        strat_dict = {'definition.tsv': definitions}
+        strat_dict = {'definition.tsv': str(definitions)}
         strat_dict.update({file.name: str(file) for file in strat_bed_files})
         batch_beds = batch.read_input_group(**strat_dict)
         command += f'--stratification {batch_beds["definition.tsv"]}'

--- a/validation/validation_runner.py
+++ b/validation/validation_runner.py
@@ -220,7 +220,7 @@ def comparison_job(
 
         # create a dictionary to pass to a the input generation
         strat_dict = {'definition.tsv': definitions}
-        strat_dict.update({file.name: file.str for file in strat_bed_files})
+        strat_dict.update({file.name: str(file) for file in strat_bed_files})
         batch_beds = batch.read_input_group(**strat_dict)
         command += f'--stratification {batch_beds["definition.tsv"]}'
 

--- a/validation/validation_runner.py
+++ b/validation/validation_runner.py
@@ -296,6 +296,7 @@ def post_results_job(
     truth_bed: str,
     joint_mt: str,
     comparison_folder: str,
+    stratified: str | None = None,
 ):
     """
     post the results to THE METAMIST using companion script
@@ -310,6 +311,7 @@ def post_results_job(
     truth_bed : source of confident regions
     joint_mt : joint-call MatrixTable
     comparison_folder :
+    stratified : stratification files, if used
     """
 
     post_job = batch.new_job(name=f'Update metamist for {sample_id}')
@@ -333,6 +335,11 @@ def post_results_job(
         f'-b {truth_bed} '
         f'--mt {joint_mt} '
     )
+
+    # add stratification files if appropraite
+    if stratified:
+        job_cmd += f'--stratified {stratified}'
+
     post_job.command(job_cmd)
 
 
@@ -415,6 +422,7 @@ def main(input_file: str, stratification: str | None):
             truth_bed=truth_bed,
             joint_mt=input_file,
             comparison_folder=comparison_folder,
+            stratified=stratification,
         )
 
     batch.run(wait=False)


### PR DESCRIPTION
Introduces the option for validation runs to include more granular 'stratification' BED files

These have been prepared, and currently sit in gs://cpg-validation-test/GRCh38_regions (where this README is also copied)

If a stratification folder is specified, the files are passed into the comparison image, and hap.py is run in stratification mode. 

Results are populated into Metamist for the Precision, Recall, and # True variants in each region (whole confident region, then each separate stratified region).

incidental: instead of taking PASS and ALL variants, we now only take PASS, as Hap.py is filtering for PASS only, meaning these results were duplicated

We are currently ignoring the Subtype rows in the extended csv. Those rows separate results out even further, e.g. by indel size. It feels like an overload to pull all that information into metamist, but it remains in the files if we want to use it