### PR TITLE
reduce memory footprint through reduced thread count

### DIFF
--- a/validation/parse_validation_results.py
+++ b/validation/parse_validation_results.py
@@ -61,7 +61,7 @@ def main(
     truth_bed: str,
     joint_mt: str,
     stratified: str | None = None,
-    no_post: bool = False,
+    dry_run: bool = False,
 ):
     """
     parses for this sample's analysis results
@@ -77,7 +77,7 @@ def main(
     truth_bed : the confident regions BED
     joint_mt : the original joint-call MatrixTable
     stratified : if analysis was stratified, this is the location of files
-    no_post : don't post to metamist
+    dry_run : don't post to metamist
     """
 
     # if a result already exists, quietly exit so as not to cancel other sample's jobs
@@ -123,7 +123,7 @@ def main(
     # print the contents, even if the metamist write fails (e.g. on test)
     logging.info(json.dumps(summary_data, indent=True))
 
-    if not no_post:
+    if not dry_run:
         AnalysisApi().create_new_analysis(
             project=get_config()['workflow']['dataset'],
             analysis_model=AnalysisModel(
@@ -150,7 +150,7 @@ if __name__ == '__main__':
         '--stratified', help='Stratification files, if used', required=False
     )
     parser.add_argument(
-        '--no_post', action='store_true', help="if present, don't write to metamist"
+        '--dry_run', action='store_true', help="if present, don't write to metamist"
     )
     args = parser.parse_args()
     main(
@@ -161,5 +161,5 @@ if __name__ == '__main__':
         truth_bed=args.b,
         joint_mt=args.mt,
         stratified=args.stratified,
-        no_post=args.no_post,
+        dry_run=args.dry_run,
     )

--- a/validation/parse_validation_results.py
+++ b/validation/parse_validation_results.py
@@ -9,6 +9,7 @@ A summary of those results are posted into Metamist
 import logging
 from argparse import ArgumentParser
 from csv import DictReader
+import json
 
 from cpg_utils import to_path
 from cpg_utils.config import get_config
@@ -60,6 +61,7 @@ def main(
     truth_bed: str,
     joint_mt: str,
     stratified: str | None = None,
+    no_post: bool = False,
 ):
     """
     parses for this sample's analysis results
@@ -75,6 +77,7 @@ def main(
     truth_bed : the confident regions BED
     joint_mt : the original joint-call MatrixTable
     stratified : if analysis was stratified, this is the location of files
+    no_post : don't post to metamist
     """
 
     # if a result already exists, quietly exit so as not to cancel other sample's jobs
@@ -118,19 +121,20 @@ def main(
         summary_data[file.name.replace(f'{cpg_id}.', '')] = str(file.absolute())
 
     # print the contents, even if the metamist write fails (e.g. on test)
-    logging.info(summary_data)
+    logging.info(json.dumps(summary_data, indent=True))
 
-    AnalysisApi().create_new_analysis(
-        project=get_config()['workflow']['dataset'],
-        analysis_model=AnalysisModel(
-            sample_ids=[cpg_id],
-            type=AnalysisType('qc'),
-            status=AnalysisStatus('completed'),
-            output=comparison_folder,
-            meta=summary_data,
-            active=True,
-        ),
-    )
+    if not no_post:
+        AnalysisApi().create_new_analysis(
+            project=get_config()['workflow']['dataset'],
+            analysis_model=AnalysisModel(
+                sample_ids=[cpg_id],
+                type=AnalysisType('qc'),
+                status=AnalysisStatus('completed'),
+                output=comparison_folder,
+                meta=summary_data,
+                active=True,
+            ),
+        )
 
 
 if __name__ == '__main__':
@@ -145,6 +149,9 @@ if __name__ == '__main__':
     parser.add_argument(
         '--stratified', help='Stratification files, if used', required=False
     )
+    parser.add_argument(
+        '--no_post', action='store_true', help="if present, don't write to metamist"
+    )
     args = parser.parse_args()
     main(
         cpg_id=args.id,
@@ -154,4 +161,5 @@ if __name__ == '__main__':
         truth_bed=args.b,
         joint_mt=args.mt,
         stratified=args.stratified,
+        no_post=args.no_post,
     )

--- a/validation/run_file.sh
+++ b/validation/run_file.sh
@@ -6,9 +6,10 @@ DATE=${1:-$(date +%F)}
 
 analysis-runner \
   --dataset validation \
-  --description "Run Exome Validation!" \
+  --description "Run Genome Validation" \
   -o $DATE \
-  --access-level test \
+  --access-level standard \
   validation/validation_runner.py \
-    -i gs://cpg-validation-test/validation/copy/copy_of_exome_628.mt \
-    -s gs://cpg-validation-test/GRCh38_regions/twist
+    -i gs://cpg-validation-main/mt/986d792a448c66a8a5cfba65434e7d1ce9b1ff_1051-validation.mt \
+    -s gs://cpg-validation-test/GRCh38_regions \
+    --no_post

--- a/validation/validation_runner.py
+++ b/validation/validation_runner.py
@@ -147,8 +147,9 @@ def comparison_job(
         job.depends_on(dependency)
 
     job.image(image_path('happy'))
-    job.memory('40Gi')
+    job.memory('20Gi')
     job.storage('40Gi')
+    job.cpu(2)
     vcf_input = batch.read_input_group(**{'vcf': ss_vcf, 'index': f'{ss_vcf}.tbi'})
     truth_input = batch.read_input_group(
         **{'vcf': truth_vcf, 'index': f'{truth_vcf}.tbi'}
@@ -192,7 +193,7 @@ def comparison_job(
         f'hap.py {truth_input["vcf"]} {vcf_input["vcf"]} '
         f'-r {batch_ref["fasta"]} -R {truth_bed} '
         f'-o {job.output}/output --leftshift '
-        f'--threads 10 --preprocess-truth '
+        f'--threads 4 --preprocess-truth '
         f'--engine-vcfeval-path=/opt/hap.py/libexec/rtg-tools-install/rtg '
         f'--engine-vcfeval-template {sdf} --engine=vcfeval '
     )

--- a/validation/validation_runner.py
+++ b/validation/validation_runner.py
@@ -293,7 +293,7 @@ def post_results_job(
     joint_mt: str,
     comparison_folder: str,
     stratified: str | None = None,
-    no_post: bool = False,
+    dry_run: bool = False,
 ):
     """
     post the results to THE METAMIST using companion script
@@ -308,7 +308,7 @@ def post_results_job(
     joint_mt : joint-call MatrixTable
     comparison_folder :
     stratified : stratification files, if used
-    no_post : if true, prevent writes to metamist
+    dry_run : if true, prevent writes to metamist
     """
 
     post_job = batch.new_job(name=f'Update metamist for {sample_id}')
@@ -332,8 +332,8 @@ def post_results_job(
         f'--mt {joint_mt} '
     )
 
-    if no_post:
-        job_cmd += '--no_post '
+    if dry_run:
+        job_cmd += '--dry_run '
 
     # add stratification files if appropraite
     if stratified:
@@ -343,13 +343,13 @@ def post_results_job(
     return post_job
 
 
-def main(input_file: str, stratification: str | None, no_post: bool = False):
+def main(input_file: str, stratification: str | None, dry_run: bool = False):
     """
     Parameters
     ----------
     input_file : path to the MT representing this joint-call
     stratification : the path to the stratification BED files
-    no_post : if True, prevent writes to Metamist
+    dry_run : if True, prevent writes to Metamist
     """
 
     input_path = Path(input_file)
@@ -423,7 +423,7 @@ def main(input_file: str, stratification: str | None, no_post: bool = False):
             joint_mt=input_file,
             comparison_folder=comparison_folder,
             stratified=stratification,
-            no_post=no_post,
+            dry_run=dry_run,
         )
 
         result_job.depends_on(comparison)
@@ -437,7 +437,7 @@ if __name__ == '__main__':
     parser.add_argument('-i', help='input_path')
     parser.add_argument('-s', help='stratification BED directory')
     parser.add_argument(
-        '--no_post', action='store_true', help='use to prevent metamist writes'
+        '--dry_run', action='store_true', help='use to prevent metamist writes'
     )
     args = parser.parse_args()
-    main(input_file=args.i, stratification=args.s, no_post=args.no_post)
+    main(input_file=args.i, stratification=args.s, dry_run=args.dry_run)


### PR DESCRIPTION
The memory usage was exploding while running, but that looks self-inflicted based on this issue: https://github.com/Illumina/hap.py/issues/53

When I was running hap.py locally it wouldn't permit > 10 threads, so I capped the threads at 10 (which sets the `threads` argument to 10, forcing the thread count).

While running on whole-genome VCFs the RAM consumption was climbing over 50GiB, and crashing the process.

Instead of arbitrarily increasing the requested RAM, cap the number of threads to force a lower memory footprint.

Reference: #16, the previous PR to update the resources provided
Reference: https://batch.hail.populationgenomics.org.au/batches/377416/jobs/10, a job failing due to thread-induced memory explosion
