### PR TITLE
Modularise MD5 check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# vscode
+.vscode/

--- a/data_transfer/gdr_manifest_md5_check.py
+++ b/data_transfer/gdr_manifest_md5_check.py
@@ -1,22 +1,34 @@
 #!/usr/bin/env python3
 
 """Checks data transfer integrity for GDR cohorts by comparing MD5 checksums."""
-
+import os
 import base64
 import binascii
 import csv
 import logging
 import sys
+
+import click
+from cloudpathlib import AnyPath
 from google.cloud import storage
 
 from cpg_utils.config import get_config
 
-MANIFEST_FILE = 'manifest.txt'
-FILENAME_COLUMN = 'filename'
-CHECKSUM_COLUMN = 'checksum'
+
+try:
+    DEFAULT_DATASET = get_config()['workflow']['dataset']
+except (KeyError, AssertionError):
+    DEFAULT_DATASET = None
 
 
-def main():
+def main(
+    dataset,
+    manifest_file_path,
+    filename_column,
+    checksum_column,
+    file_prefix='',
+    delimiter='\t',
+):
     """Main entrypoint."""
     logging.basicConfig(
         level=logging.INFO,
@@ -24,27 +36,30 @@ def main():
         datefmt='%Y-%m-%d %H:%M:%S',
         stream=sys.stderr,
     )
-
-    dataset = get_config()['workflow']['dataset']
     upload_bucket_name = f'cpg-{dataset}-main-upload'
+
+    if not manifest_file_path.startswith('gs://'):
+        manifest_file_path = os.path.join(
+            f'gs://{upload_bucket_name}', file_prefix, manifest_file_path
+        )
+
+    logging.info(f'Fetching manifest from {manifest_file_path}')
+    with AnyPath(manifest_file_path).open() as manifest_file:
+        manifest = manifest_file.read()
 
     storage_client = storage.Client()
     bucket = storage_client.get_bucket(upload_bucket_name)
 
-    manifest_blob = bucket.get_blob(MANIFEST_FILE)
-    if not manifest_blob:
-        logging.error(f'blob does not exist: {MANIFEST_FILE}')
-        sys.exit(1)
-    manifest = manifest_blob.download_as_text()
-
     any_errors = False
-    tsv_reader = csv.DictReader(manifest.splitlines(), delimiter='\t')
+    tsv_reader = csv.DictReader(manifest.splitlines(), delimiter=delimiter)
+    matches = 0
+    mismatches = 0
     for row in tsv_reader:
-        filename = row[FILENAME_COLUMN]
-        expected_md5 = row[CHECKSUM_COLUMN]
+        filename = row[filename_column]
+        expected_md5 = row[checksum_column]
 
         # Read the checksum from the blob. The checksum is base64-encoded.
-        check_blob = bucket.get_blob(filename)
+        check_blob = bucket.get_blob(os.path.join(file_prefix, filename))
         if not check_blob:
             logging.error(f'blob does not exist: {filename}')
             any_errors = True
@@ -55,13 +70,56 @@ def main():
 
         if expected_md5 == actual_md5:
             logging.info(f'match: {filename}')
+            matches += 1
         else:
             logging.error(f'mismatch: {filename}, {expected_md5=}, {actual_md5=}')
             any_errors = True
+            mismatches += 1
 
+    logging.info(f'{matches=}, {mismatches=}')
     if any_errors:
         sys.exit(1)
 
 
+# MANIFEST_FILE = 'manifest.txt'
+# FILENAME_COLUMN = 'filename'
+# CHECKSUM_COLUMN = 'checksum'
+@click.command()
+@click.option(
+    '--dataset',
+    required=DEFAULT_DATASET is None,
+    default=DEFAULT_DATASET,
+)
+@click.option('--file-prefix', default='')
+@click.option(
+    '--manifest-file-path',
+    required=False,
+    default='manifest.txt',
+)
+@click.option(
+    '--filename-column',
+    default='filename',
+)
+@click.option(
+    '--checksum-column',
+    default='checksum',
+)
+def from_cli(
+    dataset,
+    file_prefix,
+    manifest_file_path,
+    filename_column,
+    checksum_column,
+):
+    """Run the script from the command line."""
+    return main(
+        dataset=dataset,
+        file_prefix=file_prefix,
+        manifest_file_path=manifest_file_path,
+        filename_column=filename_column,
+        checksum_column=checksum_column,
+    )
+
+
 if __name__ == '__main__':
-    main()
+    from_cli()  # pylint: disable=no-value-for-parameter

--- a/data_transfer/gdr_manifest_md5_check.py
+++ b/data_transfer/gdr_manifest_md5_check.py
@@ -39,6 +39,7 @@ def main(
     upload_bucket_name = f'cpg-{dataset}-main-upload'
 
     if not manifest_file_path.startswith('gs://'):
+        # empty file_prefix gets skipped
         manifest_file_path = os.path.join(
             f'gs://{upload_bucket_name}', file_prefix, manifest_file_path
         )
@@ -57,13 +58,13 @@ def main(
     for row in tsv_reader:
         filename = row[filename_column]
         expected_md5 = row[checksum_column]
-
-        # Read the checksum from the blob. The checksum is base64-encoded.
+        # empty file_prefix gets skipped
         check_blob = bucket.get_blob(os.path.join(file_prefix, filename))
         if not check_blob:
             logging.error(f'blob does not exist: {filename}')
             any_errors = True
             continue
+        # Read the checksum from the blob. The checksum is base64-encoded.
         actual_md5 = binascii.hexlify(
             base64.urlsafe_b64decode(check_blob.md5_hash)
         ).decode('utf-8')


### PR DESCRIPTION
CLI + some flexibility, allows you to run it from the CLI without changing params.

```bash
python data_transfer/gdr_manifest_md5_check.py \
    --dataset "DATASET" \
    --file-prefix "SUBFOLDER"
```

You can omit the file-prefix if you want the root of the bucket, and you can omit the dataset if you're running through the analysis-runner.