### PR TITLE
Add ruff linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,46 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.2.0
-  hooks:
-  - id: check-yaml
-    exclude: '\.*conda/.*'
-  - id: end-of-file-fixer
-  - id: trailing-whitespace
-    exclude: '\.txt$|\.tsv$'
-  - id: check-case-conflict
-  - id: check-merge-conflict
-  - id: detect-private-key
-  - id: debug-statements
-  - id: check-added-large-files
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: check-yaml
+        exclude: '\.*conda/.*'
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        exclude: '\.txt$|\.tsv$'
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: debug-statements
+      - id: check-added-large-files
 
-- repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.31.1
-  hooks:
-  - id: markdownlint
-    args: ['--config', '.markdownlint.json']
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.31.1
+    hooks:
+      - id: markdownlint
+        args: ["--config", ".markdownlint.json"]
 
-- repo: https://github.com/ambv/black
-  rev: 22.3.0
-  hooks:
-  - id: black
+  - repo: https://github.com/ambv/black
+    rev: 22.3.0
+    hooks:
+      - id: black
 
-- repo: https://github.com/PyCQA/flake8
-  rev: '5.0.4'
-  hooks:
-  - id: flake8
-    additional_dependencies: [flake8-bugbear, flake8-quotes]
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: "v0.0.264"
+    hooks:
+      - id: ruff
 
-# Using system installation of pylint to support checking python module imports
-- repo: local
-  hooks:
-  - id: pylint
-    name: pylint
-    entry: pylint
-    language: system
-    types: [python]
+      # mypy
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.961
+    hooks:
+      - id: mypy
+        args:
+          [
+            --pretty,
+            --show-error-codes,
+            --no-strict-optional,
+            --ignore-missing-imports,
+            --install-types,
+            --non-interactive,
+          ]

--- a/data_transfer/gdr_manifest_md5_check.py
+++ b/data_transfer/gdr_manifest_md5_check.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python3
 
 """Checks data transfer integrity for GDR cohorts by comparing MD5 checksums."""
-import os
 import base64
 import binascii
 import csv
 import logging
+import os
 import sys
 
 import click
 from cloudpathlib import AnyPath
-from google.cloud import storage
-
 from cpg_utils.config import get_config
-
+from google.cloud import storage
 
 try:
     DEFAULT_DATASET = get_config()['workflow']['dataset']
@@ -22,12 +20,12 @@ except (KeyError, AssertionError):
 
 
 def main(
-    dataset,
-    manifest_file_path,
-    filename_column,
-    checksum_column,
-    file_prefix='',
-    delimiter='\t',
+    dataset: str,
+    file_prefix: str = '',
+    filename_column: str = 'filename',
+    checksum_column: str = 'checksum',
+    manifest_file_path: str = 'manifest.txt',
+    delimiter: str = '\t',
 ):
     """Main entrypoint."""
     logging.basicConfig(
@@ -41,7 +39,9 @@ def main(
     if not manifest_file_path.startswith('gs://'):
         # empty file_prefix gets skipped
         manifest_file_path = os.path.join(
-            f'gs://{upload_bucket_name}', file_prefix, manifest_file_path
+            f'gs://{upload_bucket_name}',
+            file_prefix,
+            manifest_file_path,
         )
 
     logging.info(f'Fetching manifest from {manifest_file_path}')
@@ -66,7 +66,7 @@ def main(
             continue
         # Read the checksum from the blob. The checksum is base64-encoded.
         actual_md5 = binascii.hexlify(
-            base64.urlsafe_b64decode(check_blob.md5_hash)
+            base64.urlsafe_b64decode(check_blob.md5_hash),
         ).decode('utf-8')
 
         if expected_md5 == actual_md5:
@@ -82,9 +82,6 @@ def main(
         sys.exit(1)
 
 
-# MANIFEST_FILE = 'manifest.txt'
-# FILENAME_COLUMN = 'filename'
-# CHECKSUM_COLUMN = 'checksum'
 @click.command()
 @click.option(
     '--dataset',
@@ -106,11 +103,11 @@ def main(
     default='checksum',
 )
 def from_cli(
-    dataset,
-    file_prefix,
-    manifest_file_path,
-    filename_column,
-    checksum_column,
+    dataset: str,
+    file_prefix: str = '',
+    filename_column: str = 'filename',
+    checksum_column: str = 'checksum',
+    manifest_file_path: str = 'manifest.txt',
 ):
     """Run the script from the command line."""
     return main(

--- a/data_transfer/generic_https_transfer.py
+++ b/data_transfer/generic_https_transfer.py
@@ -58,7 +58,7 @@ def main(presigned_url_file_path: str):
         # catch errors during the cURL
         j.command('set -euxo pipefail')
         j.command(
-            f'curl -L {quoted_url} | gsutil cp - {os.path.join(output_path, filename)}'
+            f'curl -L {quoted_url} | gsutil cp - {os.path.join(output_path, filename)}',
         )
 
     batch.run(wait=False)

--- a/data_transfer/subset_matrix_table.py
+++ b/data_transfer/subset_matrix_table.py
@@ -13,18 +13,19 @@ Default behaviour is to remove any sites where the requested samples
     are all HomRef. All sites can be retained with --keep_ref
 """
 
-from argparse import ArgumentParser
 import logging
 import sys
+from argparse import ArgumentParser
 
 import hail as hl
-
-from cpg_utils.hail_batch import output_path, init_batch
 from cpg_utils.config import get_config
+from cpg_utils.hail_batch import init_batch, output_path
 
 
 def subset_to_samples(
-    mt: hl.MatrixTable, samples: set[str], keep_hom_ref: bool
+    mt: hl.MatrixTable,
+    samples: set[str],
+    keep_hom_ref: bool,
 ) -> hl.MatrixTable:
     """
     checks the requested sample subset exists in this joint call
@@ -177,7 +178,9 @@ if __name__ == '__main__':
         required=True,
     )
     parser.add_argument(
-        '-s', help='One or more sample IDs, whitespace delimited', nargs='+'
+        '-s',
+        help='One or more sample IDs, whitespace delimited',
+        nargs='+',
     )
     parser.add_argument(
         '--format',
@@ -203,7 +206,7 @@ if __name__ == '__main__':
 
     if any([args.chr, args.pos]) and not all([args.chr, args.pos]):
         raise Exception(
-            f'When defining a Locus, provide both Chr & Pos: {args.chr}, {args.pos}'
+            f'When defining a Locus, provide both Chr & Pos: {args.chr}, {args.pos}',
         )
 
     init_batch()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,28 @@
 [tool.black]
 line-length = 88
 skip-string-normalization = true
+
+[tool.ruff]
+line-length = 88
+
+# ignore pydocstyle, flake8-boolean-trap (FBT)
+select = ["A", "B", "C",  "E", "F", "G", "I", "N", "Q", "S", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]
+
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "FBT", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]
+
+ignore = [
+    "ANN101",  # Missing type annotation for self in method
+    "ANN201",  # Missing return type annotation for public function
+    "E501",    # Line length too long
+    "E731",    # Do not assign a lambda expression, use a def
+    "E741",    # Ambiguous variable name
+    "G004",    # Logging statement uses f-string
+    "PLR0911", # Too many return statements
+    "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments to function call
+    "PLR0915", # Too many statements
+    "PLW0603", # Using the global statement to update `<VAR>` is discouraged
+    "PT018",   # Assertion should be broken down into multiple parts
+    "Q000",    # Single quotes found but double quotes preferred
+    "S101",    # Use of assert detected
+]

--- a/validation/mt_to_vcf.py
+++ b/validation/mt_to_vcf.py
@@ -6,7 +6,6 @@ Takes an input MT, and extracts a VCF-format representation.
 from argparse import ArgumentParser
 
 import hail as hl
-
 from cpg_utils.hail_batch import init_batch
 
 

--- a/validation/parse_validation_results.py
+++ b/validation/parse_validation_results.py
@@ -6,20 +6,18 @@ A summary of those results are posted into Metamist
 """
 
 
+import json
 import logging
 from argparse import ArgumentParser
 from csv import DictReader
-import json
 
 from cpg_utils import to_path
 from cpg_utils.config import get_config
-
 from sample_metadata.apis import AnalysisApi
-from sample_metadata.model.analysis_type import AnalysisType
 from sample_metadata.model.analysis_model import AnalysisModel
-from sample_metadata.model.analysis_status import AnalysisStatus
 from sample_metadata.model.analysis_query_model import AnalysisQueryModel
-
+from sample_metadata.model.analysis_status import AnalysisStatus
+from sample_metadata.model.analysis_type import AnalysisType
 
 ANAL_API = AnalysisApi()
 SUMMARY_KEYS = {
@@ -84,7 +82,7 @@ def main(
     if check_for_prior_result(cpg_id=cpg_id, comparison_folder=comparison_folder):
         logging.info(
             f'Sample {cpg_id} already has validation '
-            f'results logged from {comparison_folder}, quitting'
+            f'results logged from {comparison_folder}, quitting',
         )
         return
 
@@ -147,10 +145,14 @@ if __name__ == '__main__':
     parser.add_argument('-b', help='BED used')
     parser.add_argument('--mt', help='Multisample MT')
     parser.add_argument(
-        '--stratified', help='Stratification files, if used', required=False
+        '--stratified',
+        help='Stratification files, if used',
+        required=False,
     )
     parser.add_argument(
-        '--dry_run', action='store_true', help="if present, don't write to metamist"
+        '--dry_run',
+        action='store_true',
+        help="if present, don't write to metamist",
     )
     args = parser.parse_args()
     main(


### PR DESCRIPTION
The config will be constantly up for debate, this one works pretty well:

```toml
[tool.black]
line-length = 88
skip-string-normalization = true

[tool.ruff]
line-length = 88

# ignore pydocstyle, flake8-boolean-trap (FBT)
select = ["A", "B", "C",  "E", "F", "G", "I", "N", "Q", "S", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]

fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "FBT", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]

ignore = [
    "ANN101",  # Missing type annotation for self in method
    "ANN201",  # Missing return type annotation for public function
    "E501",    # Line length too long
    "E731",    # Do not assign a lambda expression, use a def
    "E741",    # Ambiguous variable name
    "G004",    # Logging statement uses f-string
    "PLR0911", # Too many return statements
    "PLR0912", # Too many branches
    "PLR0913", # Too many arguments to function call
    "PLR0915", # Too many statements
    "PLW0603", # Using the global statement to update `<VAR>` is discouraged
    "PT018",   # Assertion should be broken down into multiple parts
    "Q000",    # Single quotes found but double quotes preferred
    "S101",    # Use of assert detected
]
```