### PR TITLE
MCRI Owncloud curl transfer script

### DIFF
--- a/data_transfer/owncloud_https_transfer.py
+++ b/data_transfer/owncloud_https_transfer.py
@@ -57,7 +57,9 @@ def main(owncloud_curl_file_path: str):
         authenticate_cloud_credentials_in_job(job=j)
         # catch errors during the cURL
         j.command('set -euxo pipefail')
-        j.command(f'curl -L {curl} | gsutil cp - {os.path.join(output_path, filename)}')
+        j.command(
+            f'curl -L {curl} | gsutil cp - \'{os.path.join(output_path, filename)}'
+        )
 
     batch.run(wait=False)
 

--- a/data_transfer/owncloud_https_transfer.py
+++ b/data_transfer/owncloud_https_transfer.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3 # noqa: EXE001
 
 """
 Transfer data files from MCRI owncloud cURLs to a dataset's GCP main-upload bucket.
 """
 
 import os
-from shlex import quote
 
 import click
 import hailtop.batch as hb
@@ -18,7 +17,7 @@ from cpg_utils.hail_batch import (
 )
 
 
-@click.command('Transfer_datasets from signed URLs')
+@click.command('Transfer data from owncloud cURLs')
 @click.option('--owncloud-curl-file-path')
 def main(owncloud_curl_file_path: str):
     """

--- a/data_transfer/owncloud_https_transfer.py
+++ b/data_transfer/owncloud_https_transfer.py
@@ -50,16 +50,14 @@ def main(owncloud_curl_file_path: str):
     # may as well batch them to reduce the number of VMs
     for idx, curl in enumerate(owncloud_curls):
         url = curl.split(' ')[0]
-        filename = os.path.basename(url).split('&files=')[1]
+        filename = os.path.basename(url).split('&files=')[1].removesuffix("'")
         if '&downloadStartSecret' in filename:
             filename = filename.split('&downloadStartSecret')[0]
         j = batch.new_job(f'URL {idx} ({filename})')
         authenticate_cloud_credentials_in_job(job=j)
         # catch errors during the cURL
         j.command('set -euxo pipefail')
-        j.command(
-            f'curl -L {curl} | gsutil cp - \'{os.path.join(output_path, filename)}'
-        )
+        j.command(f'curl -L {curl} | gsutil cp - {os.path.join(output_path, filename)}')
 
     batch.run(wait=False)
 

--- a/data_transfer/owncloud_https_transfer.py
+++ b/data_transfer/owncloud_https_transfer.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+"""
+Transfer data files from MCRI owncloud cURLs to a dataset's GCP main-upload bucket.
+"""
+
+import os
+from shlex import quote
+
+import click
+import hailtop.batch as hb
+from cloudpathlib import AnyPath
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import (
+    authenticate_cloud_credentials_in_job,
+    dataset_path,
+    remote_tmpdir,
+)
+
+
+@click.command('Transfer_datasets from signed URLs')
+@click.option('--owncloud-curl-file-path')
+def main(owncloud_curl_file_path: str):
+    """
+    Given a list of presigned URLs, download the files and upload them to GCS.
+    GCP suffix in target GCP bucket is defined using analysis-runner's --output
+    """
+
+    env_config = get_config()
+    cpg_driver_image = env_config['workflow']['driver_image']
+    billing_project = env_config['hail']['billing_project']
+    dataset = env_config['workflow']['dataset']
+    output_prefix = env_config['workflow']['output_prefix']
+    assert all({billing_project, cpg_driver_image, dataset, output_prefix})
+
+    with AnyPath(owncloud_curl_file_path).open() as file:
+        owncloud_curls = [line.strip() for line in file.readlines() if line.strip()]
+
+    incorrect_urls = [url for url in owncloud_curls if not url.startswith('\'https://')]
+    if incorrect_urls:
+        raise Exception(f'Incorrect URLs: {incorrect_urls}')
+
+    sb = hb.ServiceBackend(
+        billing_project=billing_project,
+        remote_tmpdir=remote_tmpdir(),
+    )
+    batch = hb.Batch(f'transfer {dataset}', backend=sb, default_image=cpg_driver_image)
+    output_path = dataset_path(output_prefix, 'upload')
+
+    # may as well batch them to reduce the number of VMs
+    for idx, curl in enumerate(owncloud_curls):
+        url = curl.split(' ')[0]
+        filename = os.path.basename(url).split('&files=')[1]
+        if '&downloadStartSecret' in filename:
+            filename = filename.split('&downloadStartSecret')[0]
+        j = batch.new_job(f'URL {idx} ({filename})')
+        authenticate_cloud_credentials_in_job(job=j)
+        # catch errors during the cURL
+        j.command('set -euxo pipefail')
+        j.command(f'curl -L {curl} | gsutil cp - {os.path.join(output_path, filename)}')
+
+    batch.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/data_transfer/owncloud_https_transfer.py
+++ b/data_transfer/owncloud_https_transfer.py
@@ -21,7 +21,7 @@ from cpg_utils.hail_batch import (
 @click.option('--owncloud-curl-file-path')
 def main(owncloud_curl_file_path: str):
     """
-    Given a list of presigned URLs, download the files and upload them to GCS.
+    Given a list of cURL commands, download the files and upload them to GCS.
     GCP suffix in target GCP bucket is defined using analysis-runner's --output
     """
 


### PR DESCRIPTION
Transferring data from MCRI's owncloud storage requires password authentication in browser. Unfortunately, signed URLs cannot be created from the download links found in the browser. However, cURL commands can be generated from the browser page, which can then be passed to Hail batch to download. 

This script, adapted from `generic_https_transfer.py`, acts on any number of cURL commands saved into a text file, downloading and copying the files into the project's upload bucket.

[Context where this is necessary](https://github.com/populationgenomics/seqr-private/issues/105)
[Test example](https://batch.hail.populationgenomics.org.au/batches/424226/jobs/1)