### PR TITLE
Add billing project option to data dump script

### DIFF
--- a/data_transfer/create_dataset_dump_for_release.py
+++ b/data_transfer/create_dataset_dump_for_release.py
@@ -170,7 +170,7 @@ def upload_metadata_to_release(dataset: str, billing_project: str | None):
     )
 
 
-def copy_vcf_to_release(dataset: str):
+def copy_vcf_to_release(dataset: str, billing_project: str | None):
     """Copies the vcf created by the seqr loader to the metadata directory in the release bucket"""
     _query = """
              query AnalysisVCF($datasetName: String!) {
@@ -283,6 +283,8 @@ def copy_vcf_to_release(dataset: str):
         logging.info(f'{dataset}: No completed genome VCF analyses found.')
 
     # Save the paths to the .vcf.bgz and .vcf.bgz.tbi files and upload them to the release bucket
+    if not billing_project:
+        billing_project = dataset
     release_path = f'gs://cpg-{dataset}-release/{TODAY}/'
     for vcf_file_path in vcf_paths:
         release_file_path = os.path.join(release_path, vcf_file_renames[vcf_file_path])
@@ -291,7 +293,7 @@ def copy_vcf_to_release(dataset: str):
                 'gcloud',
                 'storage',
                 '--billing-project',
-                dataset,
+                billing_project,
                 'cp',
                 vcf_file_path,
                 release_file_path,
@@ -322,7 +324,7 @@ def main(dataset: str, billing_project: str | None, dry_run: bool):
     write_outputs(dataset, individual_hpo_terms, pedigrees, sample_map, output_path)
 
     if not dry_run:
-        upload_metadata_to_release(dataset)
+        upload_metadata_to_release(dataset, billing_project)
         copy_vcf_to_release(dataset)
 
 

--- a/data_transfer/create_dataset_dump_for_release.py
+++ b/data_transfer/create_dataset_dump_for_release.py
@@ -147,14 +147,18 @@ def write_outputs(
         z.write(f'{output_path}/external_translation.json')
 
 
-def upload_metadata_to_release(dataset: str):
+def upload_metadata_to_release(dataset: str, billing_project: str | None):
     """Uploads the compressed metadata.zip into a directory with today's date in the release bucket"""
 
     zip_upload_path = os.path.join(TODAY, f'{dataset}_metadata.zip')
 
     release_bucket = f'cpg-{dataset}-release'
 
-    client = storage.Client()
+    if billing_project:
+        client = storage.Client(project=billing_project)
+    else:
+        client = storage.Client()
+
     bucket = client.get_bucket(release_bucket)
 
     zip_blob = bucket.blob(zip_upload_path)
@@ -299,8 +303,9 @@ def copy_vcf_to_release(dataset: str):
 
 @click.command()
 @click.option('--dataset')
+@click.option('--billing-project', default=None)
 @click.option('--dry-run', is_flag=True)
-def main(dataset: str, dry_run: bool):
+def main(dataset: str, billing_project: str | None, dry_run: bool):
     """Creates the metadata files and saves them to the output path"""
 
     output_path = f'{dataset}_metadata'

--- a/data_transfer/create_dataset_dump_for_release.py
+++ b/data_transfer/create_dataset_dump_for_release.py
@@ -325,7 +325,7 @@ def main(dataset: str, billing_project: str | None, dry_run: bool):
 
     if not dry_run:
         upload_metadata_to_release(dataset, billing_project)
-        copy_vcf_to_release(dataset)
+        copy_vcf_to_release(dataset, billing_project)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds an option for billing-project, which needs to be set for the storage client to be able to upload to the release bucket since it is requester pays.

This should resolve the error I'm getting when the `get_bucket('cpg-dataset-release')` method is called:
>google.api_core.exceptions.BadRequest: 400 GET 
>Bucket is a requester pays bucket but no user project provided.