### PR TITLE
Use storage client bucket(), not get_bucket() in data dump script

### DIFF
--- a/data_transfer/create_dataset_dump_for_release.py
+++ b/data_transfer/create_dataset_dump_for_release.py
@@ -159,7 +159,7 @@ def upload_metadata_to_release(dataset: str, billing_project: str | None):
     else:
         client = storage.Client()
 
-    bucket = client.get_bucket(release_bucket)
+    bucket = client.bucket(release_bucket, user_project=billing_project)
 
     zip_blob = bucket.blob(zip_upload_path)
 


### PR DESCRIPTION
So I was still getting this error even when I set the project as the billing project during the `storage.Client()` initialisation. 

>google.api_core.exceptions.BadRequest: 400 GET
>Bucket is a requester pays bucket but no user project provided.

As far as I can tell, changing to `bucket()` does not instantly make a HTTP request to check if the bucket exists like `get_bucket()` does. However it does explicitly allow you to put in the `user_project` argument, which the docs say is: "[the project ID to be billed for API requests made via this instance.](https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.bucket.Bucket)". 

I'm hoping by using this instead the error will be resolved, and if it doesn't I might revert to using `subprocess` since that is already used in this script anyway.