### PR TITLE
Somalier relatedness checking script

### DIFF
--- a/analysis_scripts/somalier_relate_runner.py
+++ b/analysis_scripts/somalier_relate_runner.py
@@ -99,33 +99,26 @@ def main(
     somalier_job.memory(job_memory)
     somalier_job.cpu(job_ncpu)
 
+    somalier_job.declare_resource_group(
+        output={
+            'pairs': '{root}.pairs.tsv',
+            'samples': '{root}.samples.tsv',
+            'html': '{root}.html',
+        },
+    )
+
     somalier_job.command(
         f"""
-                somalier relate  \\
-                {" ".join(batch_input_files)} \\
-                --infer \\
-                -o related
-
-                mv related.pairs.tsv {somalier_job.output_pairs}
-                mv related.samples.tsv {somalier_job.output_samples}
-                mv related.html {somalier_job.output_html}
+            somalier relate  \\
+            {" ".join(batch_input_files)} \\
+            --infer \\
+            -o {somalier_job.output}
         """,
     )
+
     # Output writing
-    b.write_output(
-        somalier_job.output_samples,
-        str(output_path(f'{num_samples}_samples_somalier.samples.tsv', 'analysis')),
-    )
-
-    b.write_output(
-        somalier_job.output_pairs,
-        str(output_path(f'{num_samples}_samples_somalier.pairs.tsv', 'analysis')),
-    )
-    b.write_output(
-        somalier_job.output_html,
-        str(output_path(f'{num_samples}_samples_somalier.html', 'analysis')),
-    )
-
+    out_path = output_path(f'{num_samples}_samples_somalier', 'analysis')
+    b.write_output(somalier_job.output, out_path)
     b.run(wait=False)
 
 

--- a/analysis_scripts/somalier_relate_runner.py
+++ b/analysis_scripts/somalier_relate_runner.py
@@ -1,0 +1,133 @@
+# pylint: disable=missing-function-docstring,no-member
+"""
+** Adapted from Hope's script **
+https://github.com/populationgenomics/sv-workflows/blob/main/str/helper/sex_ploidy/somalier_relate_runner.py
+
+This script runs somalier relate on a set of cram.somalier files provided as input directory file path.
+Alternately, you can specify individual somalier files to compare.
+# TODO: Allow specifying different inputs (e.g. Sequencing Group IDs, external Family IDs).
+
+Comparing two directories:
+
+```bash
+ analysis-runner --dataset "dataset1" \
+    --description "Somalier relate runner" \
+    --access-level "standard" \
+    --output-dir "qc-stand-alone/dataset1/somalier" \
+    somalier_relate_runner.py --input-dir-1=gs://cpg-dataset1-main/cram --input-dir-2=gs://cpg-dataset2-main/cram
+```
+
+Comparing two files:
+
+```bash
+ analysis-runner --dataset "dataset1" \
+    --description "Somalier relate runner" \
+    --access-level "standard" \
+    --output-dir "qc-stand-alone/dataset1/somalier" \
+    somalier_relate_runner.py -i gs://cpg-dataset1-main/cram/CRAM1.cram.somalier -i gs://cpg-dataset2-main/cram/CRAM2.cram.somalier
+```
+"""
+
+import click
+from cpg_utils import to_path
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import get_batch, output_path
+
+config = get_config()
+
+SOMALIER_IMAGE = config['images']['somalier']
+
+
+@click.option(
+    '--input-dir-1',
+    help='Input directory to cram.somalier files',
+    default=None,
+)
+@click.option(
+    '--input-dir-2',
+    help='2nd (optional)input directory to cram.somalier files',
+    default=None,
+)
+@click.option(
+    '-i',
+    '--input-filepaths',
+    help='Input path to cram.somalier files',
+    multiple=True,
+)
+@click.option(
+    '--job-storage',
+    help='Storage of the Hail batch job eg 30G',
+    default='10G',
+)
+@click.option('--job-memory', help='Memory of the Hail batch job', default='8G')
+@click.option('--job-ncpu', help='Number of CPUs of the Hail batch job', default=4)
+@click.command()
+def main(
+    job_memory: str,
+    job_ncpu: int,
+    job_storage: str,
+    input_filepaths: str,
+    input_dir_1: str | None,
+    input_dir_2: str | None,
+):  # pylint: disable=missing-function-docstring
+    # Initializing Batch
+    b = get_batch()
+    if not input_dir_1 and not input_dir_2:
+        input_files = list(input_filepaths)
+        if any(not file.endswith('.somalier') for file in input_files):
+            raise ValueError('Please provide .somalier files only')
+        if len(input_files) < 2:  # noqa: PLR2004
+            raise ValueError('Please provide at least 2 input files for comparison')
+    else:
+        input_files = list(to_path(input_dir_1).glob('*.somalier'))
+        input_files = [
+            str(gs_path) for gs_path in input_files
+        ]  # coverts into a string type
+        if input_dir_2 is not None:
+            input_files_2 = list(to_path(input_dir_2).glob('*.somalier'))
+            input_files_2 = [str(gs_path) for gs_path in input_files_2]
+            input_files.extend(input_files_2)
+
+    num_samples = len(input_files)
+    batch_input_files = []
+    for each_file in input_files:
+        batch_input_files.append(b.read_input(each_file))
+
+    somalier_job = b.new_job(name=f'Somalier relate: {num_samples} samples')
+    somalier_job.image(SOMALIER_IMAGE)
+    somalier_job.storage(job_storage)
+    somalier_job.memory(job_memory)
+    somalier_job.cpu(job_ncpu)
+
+    somalier_job.command(
+        f"""
+                somalier relate  \\
+                {" ".join(batch_input_files)} \\
+                --infer \\
+                -o related
+
+                mv related.pairs.tsv {somalier_job.output_pairs}
+                mv related.samples.tsv {somalier_job.output_samples}
+                mv related.html {somalier_job.output_html}
+        """,
+    )
+    # Output writing
+    b.write_output(
+        somalier_job.output_samples,
+        str(output_path(f'{num_samples}_samples_somalier.samples.tsv', 'analysis')),
+    )
+
+    b.write_output(
+        somalier_job.output_pairs,
+        str(output_path(f'{num_samples}_samples_somalier.pairs.tsv', 'analysis')),
+    )
+    b.write_output(
+        somalier_job.output_html,
+        str(output_path(f'{num_samples}_samples_somalier.html', 'analysis')),
+    )
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
This borrows almost entirely from the SV-Workflows script written by Hope: https://github.com/populationgenomics/sv-workflows/blob/main/str/helper/sex_ploidy/somalier_relate_runner.py

The main change is to allow specifying input file paths with the `-i` option, which will let us specify the exact somalier files to compare. I've added a `TODO` comment with a note that we should extend this functionality so that the script can take sequencing group IDs or even Family IDs as inputs, then the somalier files for these inputs could be found through Metamist.