### PR TITLE
Add new stage name into DatasetVCF filter

### DIFF
--- a/data_transfer/create_dataset_dump_for_release.py
+++ b/data_transfer/create_dataset_dump_for_release.py
@@ -259,11 +259,7 @@ def copy_vcf_to_release(dataset: str, billing_project: str | None):
     vcf_analyses = [
         analysis
         for analysis in analyses
-        if (
-            ('stage', 'DatasetVCF') in analysis['meta'].items()
-            or ('stage', 'AnnotatedDatasetMtToVcfWithHailQuery')
-            in analysis['meta'].items()
-        )
+        if analysis['meta'].get('stage') in ['DatasetVCF', 'AnnotatedDatasetMtToVcfWithHailQuery']
     ]
 
     if not vcf_analyses:

--- a/data_transfer/create_dataset_dump_for_release.py
+++ b/data_transfer/create_dataset_dump_for_release.py
@@ -259,7 +259,10 @@ def copy_vcf_to_release(dataset: str, billing_project: str | None):
     vcf_analyses = [
         analysis
         for analysis in analyses
-        if ('stage', 'DatasetVCF') in analysis['meta'].items()
+        if (
+            ('stage', 'DatasetVCF') in analysis['meta'].items() or
+            ('stage', 'AnnotatedDatasetMtToVcfWithHailQuery') in analysis['meta'].items()
+        )
     ]
 
     if not vcf_analyses:

--- a/data_transfer/create_dataset_dump_for_release.py
+++ b/data_transfer/create_dataset_dump_for_release.py
@@ -259,7 +259,8 @@ def copy_vcf_to_release(dataset: str, billing_project: str | None):
     vcf_analyses = [
         analysis
         for analysis in analyses
-        if analysis['meta'].get('stage') in ['DatasetVCF', 'AnnotatedDatasetMtToVcfWithHailQuery']
+        if analysis['meta'].get('stage')
+        in ['DatasetVCF', 'AnnotatedDatasetMtToVcfWithHailQuery']
     ]
 
     if not vcf_analyses:

--- a/data_transfer/create_dataset_dump_for_release.py
+++ b/data_transfer/create_dataset_dump_for_release.py
@@ -260,8 +260,9 @@ def copy_vcf_to_release(dataset: str, billing_project: str | None):
         analysis
         for analysis in analyses
         if (
-            ('stage', 'DatasetVCF') in analysis['meta'].items() or
-            ('stage', 'AnnotatedDatasetMtToVcfWithHailQuery') in analysis['meta'].items()
+            ('stage', 'DatasetVCF') in analysis['meta'].items()
+            or ('stage', 'AnnotatedDatasetMtToVcfWithHailQuery')
+            in analysis['meta'].items()
         )
     ]
 


### PR DESCRIPTION
Minor update to this dataset dump script which collects DatasetVCF analyses from Metamist and stages them into the release bucket

Allows for analyses written with `meta.stage = 'AnnotatedDatasetMtToVcfWithHailQuery'` to be found 

This whole script could probably be refactored, but right now it works well enough to generate metadata dumps and stage whole dataset VCFs for release.