### PR TITLE
Patch to Table-from-TSV scripts

### DIFF
--- a/reference_scripts/custom_hail_ingestion_script.py
+++ b/reference_scripts/custom_hail_ingestion_script.py
@@ -8,25 +8,18 @@ hail_batch.init_batch()
 # Parse command line arguments
 parser = argparse.ArgumentParser(description='Import TSV file into Hail Table format')
 parser.add_argument(
-    'input_file',
-    type=str,
+    '--input',
     help='Path to the input TSV file (can be gzipped)',
     required=True,
 )
 parser.add_argument(
     '--output',
-    '-o',
-    type=str,
-    default=None,
-    help='Output path for Hail table (default: input_file.ht)',
+    help='Output path for Hail table',
     required=True,
 )
-
 args = parser.parse_args()
+
 reference_genome = 'GRCh38'
-output_path = args.output
-# Define paths
-tsv_path = args.input_file
 
 # 1. Define the input types for the initial table import
 # We import chrom/pos/ref/alt as strings/ints first to transform them
@@ -39,7 +32,7 @@ input_types = {
 }
 
 # 2. Load the TSV
-ht = hl.import_table(tsv_path, types=input_types, delimiter='\t', force_bgz=True)
+ht = hl.import_table(args.input, types=input_types, delimiter='\t', force_bgz=True)
 
 # 3. Transform to standard Hail genomic format
 # We create a 'locus' object and an 'alleles' array
@@ -54,5 +47,5 @@ ht = ht.key_by('locus', 'alleles')
 ht.describe()
 
 # Write the table to disk in Hail format for later use
-ht.write(output_path, overwrite=True)
-print(f'Table successfully written to: {output_path}')
+ht.write(args.output, overwrite=True)
+print(f'Table successfully written to: {args.output}')

--- a/reference_scripts/custom_merge_script.py
+++ b/reference_scripts/custom_merge_script.py
@@ -36,7 +36,7 @@ def merge_hail_tables(table_paths: list[str], output_path: str) -> None:
     opened_tables = [hl.read_table(each_path) for each_path in table_paths]
 
     # 2. Perform the union (concatenate rows)
-    merged_ht = opened_tables[0].union(table_paths[1:])
+    merged_ht = opened_tables[0].union(*opened_tables[1:])
 
     # 3. Write the result to a persistent location
     merged_ht.write(output_path, overwrite=True)

--- a/reference_scripts/custom_merge_script.py
+++ b/reference_scripts/custom_merge_script.py
@@ -11,7 +11,7 @@ parser.add_argument(
     '--input',
     required=True,
     nargs='+',
-    help='Path to the input hail table',
+    help='Paths to the input Hail tables to merge',
 )
 parser.add_argument(
     '--output',


### PR DESCRIPTION
See failure mode in https://batch.hail.populationgenomics.org.au/batches/1125228/jobs/1, clash between positional (non `--flag`) argument and `required=True` directive.

This updates the argparse arguments to be valid, and adjusts the second script to take an arbitrary number of tables as arguments. Not sure if that behaviour will ever be used...