### PR TITLE
Add a HT-to-VCF-extraction-only script

### DIFF
--- a/reference_scripts/export_ht_to_vcf.py
+++ b/reference_scripts/export_ht_to_vcf.py
@@ -25,11 +25,11 @@ def write_ht_as_vcf(ht_path: str, output_path: str) -> None:
 if __name__ == '__main__':
     hail_batch.init_batch()
 
-    parser = argparse.ArgumentParser(description='Read a VCF and export it as a VCF.')
+    parser = argparse.ArgumentParser(description='Read a Hail Table and export it as a VCF.')
     parser.add_argument(
         '--input',
         required=True,
-        help='HT Path to write as VCF',
+        help='Input Hail Table path to export as VCF',
     )
     parser.add_argument(
         '--output',

--- a/reference_scripts/export_ht_to_vcf.py
+++ b/reference_scripts/export_ht_to_vcf.py
@@ -1,0 +1,41 @@
+"""
+Single purpose script to export a VCF version of a HT. This is currently specific to the [REDACTED] use case, but
+could be made generic.
+
+If this became generic, we would need to take a list/config for the fields which need to be migrated to the vcf INFO.
+"""
+
+import argparse
+
+import hail as hl
+from cpg_utils import hail_batch
+
+
+def write_ht_as_vcf(ht_path: str, output_path: str) -> None:
+    """Reads the HT which was just written, moves annotation into INFO, and writes as a VCF."""
+    ht = hl.read_table(ht_path)
+    ht = ht.transmute(
+        info=hl.Struct(
+            avis=ht.avis,
+        ),
+    )
+    hl.export_vcf(ht, output_path, tabix=True)
+
+
+if __name__ == '__main__':
+    hail_batch.init_batch()
+
+    parser = argparse.ArgumentParser(description='Read a VCF and export it as a VCF.')
+    parser.add_argument(
+        '--input',
+        required=True,
+        help='HT Path to write as VCF',
+    )
+    parser.add_argument(
+        '--output',
+        required=True,
+        help='Output path for VCF of Hail Table',
+    )
+    args = parser.parse_args()
+
+    write_ht_as_vcf(args.output, args.output)

--- a/reference_scripts/export_ht_to_vcf.py
+++ b/reference_scripts/export_ht_to_vcf.py
@@ -38,4 +38,4 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    write_ht_as_vcf(args.output, args.output)
+    write_ht_as_vcf(args.input, args.output)


### PR DESCRIPTION
Previous process (merge HTs into a single HT, optionally also export that as a VCF) partially worked. We have a combined HT but no VCF.

This extracts out the VCF write logic into a separate script so we can have another go, without needing the whole HT to be regenerated.