### PR TITLE
Reheader AVI files

### DIFF
--- a/reference_scripts/reheader_files.sh
+++ b/reference_scripts/reheader_files.sh
@@ -4,5 +4,5 @@ IN=$1
 OUT=$2
 
 
-set -euo pipefail
-gcloud storage cat "${IN}" | gunzip | awk '{if(NR==1){print "#CHROM\tPOS\tREF\tALT\tavis\tphred"}else{print $0}}' | bgzip -c | gcloud storage cp "${OUT}"
+set -euxo pipefail
+gcloud storage cat "${IN}" | gunzip | awk '{if(NR==1){print "#CHROM\tPOS\tREF\tALT\tavis\tphred"}else{print $0}}' | bgzip -c | gcloud storage cp - "${OUT}"

--- a/reference_scripts/reheader_files.sh
+++ b/reference_scripts/reheader_files.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+IN=$1
+OUT=$2
+
+gcloud storage cat "${IN}" | gunzip | awk '{if(NR==1){print "#CHROM\tPOS\tREF\tALT\tavis\tphred"}else{print $0}}' | bgzip -c | gcloud storage cp "${OUT}"

--- a/reference_scripts/reheader_files.sh
+++ b/reference_scripts/reheader_files.sh
@@ -3,4 +3,6 @@
 IN=$1
 OUT=$2
 
+
+set -euo pipefail
 gcloud storage cat "${IN}" | gunzip | awk '{if(NR==1){print "#CHROM\tPOS\tREF\tALT\tavis\tphred"}else{print $0}}' | bgzip -c | gcloud storage cp "${OUT}"


### PR DESCRIPTION
Script to do stream based reheadering of files from Google with mismatched header & data lines

Tested here: https://batch.hail.populationgenomics.org.au/batches/1127796/jobs/1

- stream in using `gcloud storage cat`
- gunzip to decompress
- awk to do first-line replacement, otherwise print lines in full
- recompress with bgzip
- stream back to new location with `gcloud storage cp - <out>`