### PR TITLE
add the phred column to AVI TSV-> HT parser

### DIFF
--- a/reference_scripts/custom_hail_ingestion_script.py
+++ b/reference_scripts/custom_hail_ingestion_script.py
@@ -35,6 +35,7 @@ input_types = {
     'REF': hl.tstr,
     'ALT': hl.tstr,
     'avis': hl.tfloat64,
+    'phred': hl.tfloat64,
 }
 
 # 2. Load the TSV


### PR DESCRIPTION
Follow-on from #51 
Adds the phred column and corresponding type into the AVI -> HT parsing script